### PR TITLE
firmware: installation_set: Support figuring the active/inactive set

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -7,4 +7,8 @@ extern crate git_version;
 
 fn main() {
     git_version::set_env();
+
+    // Run in single thread due the active/inactive tests not
+    // supporting to run in parallel for now.
+    println!("cargo:rustc-env=RUST_TEST_THREADS=1");
 }

--- a/src/firmware/installation_set.rs
+++ b/src/firmware/installation_set.rs
@@ -1,0 +1,123 @@
+// Copyright (C) 2017, 2018 O.S. Systems Sofware LTDA
+//
+// SPDX-License-Identifier: MPL-2.0
+//
+
+use failure;
+use firmware::hook::run_script;
+use std::fmt;
+use std::result;
+use std::str::FromStr;
+
+use Result;
+
+const GET_SCRIPT: &str = "updatehub-active-get";
+const SET_SCRIPT: &str = "updatehub-active-set";
+
+#[derive(PartialEq, Debug, Copy, Clone)]
+pub enum Set {
+    A,
+    B,
+}
+
+impl FromStr for Set {
+    type Err = failure::Error;
+
+    fn from_str(s: &str) -> result::Result<Self, Self::Err> {
+        match s.parse::<u8>() {
+            Ok(0) => Ok(Set::A),
+            Ok(1) => Ok(Set::B),
+            Ok(v) => bail!("{} is a invalid value. The only know ones are 0 or 1", v),
+            Err(e) => Err(e.into()),
+        }
+    }
+}
+
+impl fmt::Display for Set {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Set::A => "0",
+                Set::B => "1",
+            }
+        )
+    }
+}
+
+pub fn active() -> Result<Set> {
+    Ok(run_script(GET_SCRIPT)?.parse()?)
+}
+
+pub fn inactive() -> Result<Set> {
+    match active()? {
+        Set::A => Ok(Set::B),
+        Set::B => Ok(Set::A),
+    }
+}
+
+pub fn swap_active() -> Result<()> {
+    let _ = run_script(&format!("{} {}", SET_SCRIPT, inactive()?))?;
+    Ok(())
+}
+
+#[test]
+fn as_str() {
+    assert_eq!("0", format!("{}", Set::A));
+    assert_eq!("1", format!("{}", Set::B));
+}
+
+#[test]
+fn works() {
+    use std::env;
+    use tempfile::tempdir;
+
+    // create the fake backend
+    let tmpdir = tempdir().unwrap();
+    let tmpdir = tmpdir.path();
+    env::set_var("PATH", format!("{}", &tmpdir.to_string_lossy()));
+
+    let create_fake_backend = |active: usize| {
+        use std::fs::{create_dir_all, metadata, File};
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+
+        create_dir_all(&tmpdir).unwrap();
+
+        let mut file = File::create(&tmpdir.join(GET_SCRIPT)).unwrap();
+        writeln!(file, "#!/bin/sh\necho {}", active).unwrap();
+
+        let mut permissions = metadata(tmpdir).unwrap().permissions();
+
+        permissions.set_mode(0o755);
+        file.set_permissions(permissions).unwrap();
+
+        let mut file = File::create(&tmpdir.join(SET_SCRIPT)).unwrap();
+        writeln!(file, "#!/bin/sh\nexit 0").unwrap();
+
+        let mut permissions = metadata(tmpdir).unwrap().permissions();
+        permissions.set_mode(0o755);
+        file.set_permissions(permissions).unwrap();
+    };
+
+    // Create a fake backend using 0 as active. It must test the
+    // following:
+    // - active is A
+    // - inactive is B
+    // - swap works
+    create_fake_backend(0);
+    assert_eq!(active().unwrap(), Set::A);
+    assert_eq!(inactive().unwrap(), Set::B);
+    assert!(swap_active().is_ok());
+
+    // Create a fake backend using 1 as active. It must test the
+    // following:
+    // - active is B
+    // - inactive is A
+    // - swap works
+    create_fake_backend(1);
+    assert_eq!(active().unwrap(), Set::B);
+    assert_eq!(inactive().unwrap(), Set::A);
+    assert!(swap_active().is_ok());
+}

--- a/src/firmware/mod.rs
+++ b/src/firmware/mod.rs
@@ -13,6 +13,8 @@ use self::metadata_value::MetadataValue;
 mod hook;
 use self::hook::{run_hook, run_hooks_from_dir};
 
+pub mod installation_set;
+
 #[cfg(test)]
 pub mod tests;
 

--- a/src/firmware/tests.rs
+++ b/src/firmware/tests.rs
@@ -96,6 +96,32 @@ pub fn create_fake_metadata(device: FakeDevice) -> PathBuf {
     tmpdir
 }
 
+pub fn create_fake_installation_set(tmpdir: &Path, active: usize) {
+    use std::fs::{create_dir_all, metadata, File};
+    use std::io::Write;
+    use std::os::unix::fs::PermissionsExt;
+
+    const GET_SCRIPT: &str = "updatehub-active-get";
+    const SET_SCRIPT: &str = "updatehub-active-set";
+
+    create_dir_all(&tmpdir).unwrap();
+
+    let mut file = File::create(&tmpdir.join(GET_SCRIPT)).unwrap();
+    writeln!(file, "#!/bin/sh\necho {}", active).unwrap();
+
+    let mut permissions = metadata(tmpdir).unwrap().permissions();
+
+    permissions.set_mode(0o755);
+    file.set_permissions(permissions).unwrap();
+
+    let mut file = File::create(&tmpdir.join(SET_SCRIPT)).unwrap();
+    writeln!(file, "#!/bin/sh\nexit 0").unwrap();
+
+    let mut permissions = metadata(tmpdir).unwrap().permissions();
+    permissions.set_mode(0o755);
+    file.set_permissions(permissions).unwrap();
+}
+
 #[test]
 fn run_multiple_hooks_in_a_dir() {
     let tmpdir = tempdir().unwrap().path().to_path_buf();

--- a/src/update_package/tests.rs
+++ b/src/update_package/tests.rs
@@ -16,13 +16,24 @@ pub fn get_update_json() -> serde_json::Value {
             "supported-hardware": ["board"],
             "objects":
             [
-                {
-                    "mode": "test",
-                    "filename": "testfile",
-                    "target": "/dev/device1",
-                    "sha256sum": SHA256SUM,
-                    "size": 10
-                }
+                [
+                    {
+                        "mode": "test",
+                        "filename": "testfile",
+                        "target": "/dev/device1",
+                        "sha256sum": SHA256SUM,
+                        "size": 10
+                    }
+                ],
+                [
+                    {
+                        "mode": "test",
+                        "filename": "testfile",
+                        "target": "/dev/device2",
+                        "sha256sum": SHA256SUM,
+                        "size": 10
+                    }
+                ]
             ]
         }
     )
@@ -63,7 +74,11 @@ fn missing_object_file() {
     let u = get_update_package();
     let settings = create_fake_settings();
 
-    assert_eq!(u.filter_objects(&settings, &ObjectStatus::Missing).len(), 1);
+    assert_eq!(
+        u.filter_objects(&settings, InstallationSet::A, &ObjectStatus::Missing)
+            .len(),
+        1
+    );
 }
 
 #[test]
@@ -74,22 +89,22 @@ fn complete_object_file() {
     create_fake_object(&settings);
 
     assert!(
-        u.filter_objects(&settings, &ObjectStatus::Missing)
+        u.filter_objects(&settings, InstallationSet::A, &ObjectStatus::Missing)
             .is_empty()
     );
 
     assert!(
-        u.filter_objects(&settings, &ObjectStatus::Incomplete)
+        u.filter_objects(&settings, InstallationSet::A, &ObjectStatus::Incomplete)
             .is_empty()
     );
 
     assert!(
-        u.filter_objects(&settings, &ObjectStatus::Corrupted)
+        u.filter_objects(&settings, InstallationSet::A, &ObjectStatus::Corrupted)
             .is_empty()
     );
 
     assert_eq!(
-        u.filter_objects(&settings, &ObjectStatus::Ready)
+        u.filter_objects(&settings, InstallationSet::A, &ObjectStatus::Ready)
             .iter()
             .count(),
         1


### PR DESCRIPTION
This adds the firmware::installation_set::Set abstraction which
provides the Active/Inactive support and enables the system to decide
where to do the installation of the update package.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>