### PR TITLE
Initial implementation of state change callback

### DIFF
--- a/src/states/download.rs
+++ b/src/states/download.rs
@@ -21,6 +21,10 @@ create_state_step!(Download => Idle);
 create_state_step!(Download => Install(update_package));
 
 impl StateChangeImpl for State<Download> {
+    fn callback_state_name(&self) -> Option<&'static str> {
+        Some("download")
+    }
+
     fn handle(self) -> Result<StateMachine> {
         let installation_set = installation_set::inactive()?;
 

--- a/src/states/install.rs
+++ b/src/states/install.rs
@@ -18,8 +18,10 @@ create_state_step!(Install => Idle);
 create_state_step!(Install => Reboot);
 
 impl StateChangeImpl for State<Install> {
-    // FIXME: When adding state-chance hooks, we need to go to Idle if
-    // cancelled.
+    fn callback_state_name(&self) -> Option<&'static str> {
+        Some("install")
+    }
+
     fn handle(mut self) -> Result<StateMachine> {
         let package_uid = self.state.update_package.package_uid();
         info!("Installing update: {}", &package_uid);

--- a/src/states/mod.rs
+++ b/src/states/mod.rs
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: MPL-2.0
 //
 
+#![allow(dead_code)]
+
 //! Controls the state machine of the system
 //!
 //! It supports following states, and transitions, as shown in the
@@ -29,6 +31,7 @@ mod park;
 mod poll;
 mod probe;
 mod reboot;
+mod transition;
 
 use Result;
 

--- a/src/states/reboot.rs
+++ b/src/states/reboot.rs
@@ -14,8 +14,10 @@ pub struct Reboot {}
 create_state_step!(Reboot => Idle);
 
 impl StateChangeImpl for State<Reboot> {
-    // FIXME: When adding state-chance hooks, we need to go to Idle if
-    // cancelled.
+    fn callback_state_name(&self) -> Option<&'static str> {
+        Some("reboot")
+    }
+
     fn handle(self) -> Result<StateMachine> {
         info!("Triggering reboot");
         let output = easy_process::run("reboot")?;

--- a/src/states/transition.rs
+++ b/src/states/transition.rs
@@ -1,0 +1,105 @@
+// Copyright (C) 2018 O.S. Systems Sofware LTDA
+//
+// SPDX-License-Identifier: MPL-2.0
+//
+
+use Result;
+
+use std::path::Path;
+
+const STATE_CHANGE_CALLBACK: &str = "state-change-callback";
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum Transition {
+    Continue,
+    Cancel,
+}
+
+pub(crate) fn state_change_callback(path: &Path, state: &'static str) -> Result<Transition> {
+    use easy_process;
+    use std::io;
+
+    let callback = path.join(STATE_CHANGE_CALLBACK);
+    if !callback.exists() {
+        return Ok(Transition::Continue);
+    }
+
+    let output = easy_process::run(&format!("{} {}", &callback.to_string_lossy(), &state))?;
+
+    for err in output.stderr.lines() {
+        error!("{} (stderr): {}", path.display(), err);
+    }
+
+    let stdout: Vec<_> = output.stdout.trim().splitn(2, ' ').collect();
+    match stdout[..] {
+        ["cancel"] => Ok(Transition::Cancel),
+        [""] => Ok(Transition::Continue),
+        _ => Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "Invalid format found while running 'state-change-callback' \
+                 hook for state '{}'",
+                &state
+            ),
+        ).into()),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use tempfile;
+
+    const CALLBACK_STATE_NAME: &'static str = "test_state";
+
+    fn create_state_change_callback_hook(content: &str) -> tempfile::TempDir {
+        use firmware::tests::create_hook;
+
+        let tmpdir = tempfile::tempdir().unwrap();
+        let tmpdir = tmpdir;
+
+        create_hook(tmpdir.path().join(STATE_CHANGE_CALLBACK), content);
+        tmpdir
+    }
+
+    #[test]
+    fn cancel() {
+        let script = "#!/bin/sh\necho cancel";
+        let tmpdir = create_state_change_callback_hook(&script);
+        assert_eq!(
+            state_change_callback(&tmpdir.path(), CALLBACK_STATE_NAME).unwrap(),
+            Transition::Cancel,
+            "Unexpected result using content {:?}",
+            script,
+        );
+    }
+
+    #[test]
+    fn continue_transition() {
+        let script = "#!/bin/sh\necho ";
+        let tmpdir = create_state_change_callback_hook(&script);
+        assert_eq!(
+            state_change_callback(&tmpdir.path(), CALLBACK_STATE_NAME).unwrap(),
+            Transition::Continue,
+            "Unexpected result using content {:?}",
+            script,
+        );
+    }
+
+    #[test]
+    fn non_existing_hook() {
+        assert_eq!(
+            state_change_callback(&Path::new("/NaN"), CALLBACK_STATE_NAME).unwrap(),
+            Transition::Continue,
+            "Unexpected result for non-existing hook",
+        );
+    }
+
+    #[test]
+    fn is_error() {
+        for script in &["#!/bin/sh\necho 123", "#!/bin/sh\necho 123\ncancel"] {
+            let tmpdir = create_state_change_callback_hook(script);
+            assert!(state_change_callback(&tmpdir.path(), CALLBACK_STATE_NAME).is_err());
+        }
+    }
+}


### PR DESCRIPTION
This runs callbacks when the state machine attempts to change into `Download` and `Install`; callbacks may cancel the transition, returning the state machine to `Idle`.