### PR TITLE
Add state change callback support

### DIFF
--- a/src/states/download.rs
+++ b/src/states/download.rs
@@ -7,7 +7,7 @@ use Result;
 
 use client::Api;
 use firmware::installation_set;
-use states::{Idle, Install, State, StateChangeImpl, StateMachine};
+use states::{Idle, Install, State, StateChangeImpl, StateMachine, TransitionCallback};
 use std::fs;
 use update_package::{ObjectStatus, UpdatePackage};
 use walkdir::WalkDir;
@@ -19,6 +19,12 @@ pub struct Download {
 
 create_state_step!(Download => Idle);
 create_state_step!(Download => Install(update_package));
+
+impl TransitionCallback for State<Download> {
+    fn callback_state_name(&self) -> &'static str {
+        "download"
+    }
+}
 
 impl StateChangeImpl for State<Download> {
     fn handle(self) -> Result<StateMachine> {
@@ -189,5 +195,11 @@ mod test {
             &sha256sum,
             "Checksum mismatch"
         );
+    }
+
+    #[test]
+    fn download_has_transition_callback_trait() {
+        let download_state = fake_download_state();
+        assert_eq!(download_state.callback_state_name(), "download");
     }
 }

--- a/src/states/mod.rs
+++ b/src/states/mod.rs
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: MPL-2.0
 //
 
+#![allow(dead_code)]
+
 //! Controls the state machine of the system
 //!
 //! It supports following states, and transitions, as shown in the
@@ -29,6 +31,7 @@ mod park;
 mod poll;
 mod probe;
 mod reboot;
+mod transition;
 
 use Result;
 

--- a/src/states/reboot.rs
+++ b/src/states/reboot.rs
@@ -6,16 +6,20 @@
 use Result;
 
 use easy_process;
-use states::{Idle, State, StateChangeImpl, StateMachine};
+use states::{Idle, State, StateChangeImpl, StateMachine, TransitionCallback};
 
 #[derive(Debug, PartialEq)]
 pub struct Reboot {}
 
 create_state_step!(Reboot => Idle);
 
+impl TransitionCallback for State<Reboot> {
+    fn callback_state_name(&self) -> &'static str {
+        "reboot"
+    }
+}
+
 impl StateChangeImpl for State<Reboot> {
-    // FIXME: When adding state-chance hooks, we need to go to Idle if
-    // cancelled.
     fn handle(self) -> Result<StateMachine> {
         info!("Triggering reboot");
         let output = easy_process::run("reboot")?;
@@ -83,5 +87,11 @@ mod test {
 
         assert!(machine.is_ok(), "Error: {:?}", machine);
         assert_state!(machine, Idle);
+    }
+
+    #[test]
+    fn reboot_has_transition_callback_trait() {
+        let state = fake_reboot_state();
+        assert_eq!(state.callback_state_name(), "reboot");
     }
 }

--- a/src/states/transition.rs
+++ b/src/states/transition.rs
@@ -1,0 +1,103 @@
+// Copyright (C) 2018 O.S. Systems Sofware LTDA
+//
+// SPDX-License-Identifier: MPL-2.0
+//
+
+use Result;
+
+use std::path::Path;
+
+const STATE_CHANGE_CALLBACK: &str = "state-change-callback";
+
+#[derive(Debug, PartialEq)]
+pub(super) enum Transition {
+    Continue,
+    Cancel,
+}
+
+pub(super) fn state_change_callback(path: &Path, state: &'static str) -> Result<Transition> {
+    use easy_process;
+    use std::io;
+
+    let callback = path.join(STATE_CHANGE_CALLBACK);
+    if !callback.exists() {
+        return Ok(Transition::Continue);
+    }
+
+    let output = easy_process::run(&format!("{} {}", &callback.to_string_lossy(), &state))?;
+    for err in output.stderr.lines() {
+        error!("{} (stderr): {}", path.display(), err);
+    }
+
+    match output.stdout.trim() {
+        "cancel" => Ok(Transition::Cancel),
+        "" => Ok(Transition::Continue),
+        _ => Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "Invalid format found while running 'state-change-callback' \
+                 hook for state '{}'",
+                &state
+            ),
+        ).into()),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use tempfile;
+
+    const CALLBACK_STATE_NAME: &'static str = "test_state";
+
+    fn create_state_change_callback_hook(content: &str) -> tempfile::TempDir {
+        use firmware::tests::create_hook;
+
+        let tmpdir = tempfile::tempdir().unwrap();
+        let tmpdir = tmpdir;
+
+        create_hook(tmpdir.path().join(STATE_CHANGE_CALLBACK), content);
+        tmpdir
+    }
+
+    #[test]
+    fn cancel() {
+        let script = "#!/bin/sh\necho cancel";
+        let tmpdir = create_state_change_callback_hook(&script);
+        assert_eq!(
+            state_change_callback(&tmpdir.path(), CALLBACK_STATE_NAME).unwrap(),
+            Transition::Cancel,
+            "Unexpected result using content {:?}",
+            script,
+        );
+    }
+
+    #[test]
+    fn continue_transition() {
+        let script = "#!/bin/sh\necho ";
+        let tmpdir = create_state_change_callback_hook(&script);
+        assert_eq!(
+            state_change_callback(&tmpdir.path(), CALLBACK_STATE_NAME).unwrap(),
+            Transition::Continue,
+            "Unexpected result using content {:?}",
+            script,
+        );
+    }
+
+    #[test]
+    fn non_existing_hook() {
+        assert_eq!(
+            state_change_callback(&Path::new("/NaN"), CALLBACK_STATE_NAME).unwrap(),
+            Transition::Continue,
+            "Unexpected result for non-existing hook",
+        );
+    }
+
+    #[test]
+    fn is_error() {
+        for script in &["#!/bin/sh\necho 123", "#!/bin/sh\necho 123\ncancel"] {
+            let tmpdir = create_state_change_callback_hook(script);
+            assert!(state_change_callback(&tmpdir.path(), CALLBACK_STATE_NAME).is_err());
+        }
+    }
+}


### PR DESCRIPTION
`State::handle_with_callback` verifies the return of the callback script to decide if it goes to the next state or to `Idle`.

The support has been added to the following states:

- Download
- Install
- Reboot

This commit has been passed on the initial proposal of Elias Gabriel Amaral da Silva <tolkiendili@gmail.com> sent in #2 .

We reworked the proposed code to use a new trait and also added few tests to ensures that the `TransitionCallback` trait is implemented for all required states.
