### PR TITLE
runtime_settings: Provide an API for use by inner modules

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -70,7 +70,7 @@ impl<'a> Api<'a> {
                 &self.settings.network.server_address
             )).header(
                 HeaderName::from_static("api-retries"),
-                self.runtime_settings.polling.retries,
+                self.runtime_settings.retries(),
             ).json(&self.firmware)
             .send()?;
 

--- a/src/runtime_settings.rs
+++ b/src/runtime_settings.rs
@@ -16,19 +16,21 @@ use serde_helpers::{de, ser};
 
 #[derive(Debug, Default, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "PascalCase")]
-pub struct RuntimeSettings {
-    pub polling: RuntimePolling,
-    pub update: RuntimeUpdate,
+pub(crate) struct RuntimeSettings {
+    polling: RuntimePolling,
+    update: RuntimeUpdate,
     #[serde(skip)]
     path: PathBuf,
+    #[serde(skip)]
+    persistent: bool,
 }
 
 impl RuntimeSettings {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self::default()
     }
 
-    pub fn load(mut self, path: &str) -> Result<Self> {
+    pub(crate) fn load(mut self, path: &str) -> Result<Self> {
         use std::{fs::File, io::Read};
 
         let path = Path::new(path);
@@ -58,24 +60,82 @@ impl RuntimeSettings {
         Ok(serde_ini::from_str::<Self>(content)?)
     }
 
-    pub fn save(&self) -> Result<usize> {
+    fn save(&self) -> Result<()> {
         use std::{fs::File, io::Write};
+
+        if !self.persistent {
+            debug!("Skipping runtime settings save, using non-persistent.");
+            return Ok(());
+        }
 
         debug!(
             "Saving runtime settings from '{}'...",
             &self.path.to_string_lossy()
         );
 
-        Ok(File::create(&self.path)?.write(self.serialize()?.as_bytes())?)
+        File::create(&self.path)?.write_all(self.serialize()?.as_bytes())?;
+        Ok(())
     }
 
     fn serialize(&self) -> Result<String> {
         Ok(serde_ini::to_string(&self)?)
     }
+
+    pub(crate) fn enable_persistency(&mut self) {
+        self.persistent = true;
+    }
+
+    pub(crate) fn is_polling_forced(&self) -> bool {
+        self.polling.now
+    }
+
+    pub(crate) fn force_poll(&mut self) -> Result<()> {
+        self.polling.now = true;
+        self.save()
+    }
+
+    pub(crate) fn retries(&self) -> usize {
+        self.polling.retries
+    }
+
+    pub(crate) fn inc_retries(&mut self) {
+        self.polling.retries += 1;
+    }
+
+    pub(crate) fn clear_retries(&mut self) {
+        self.polling.retries = 0;
+    }
+
+    pub(crate) fn polling_extra_interval(&self) -> Option<Duration> {
+        self.polling.extra_interval
+    }
+
+    pub(crate) fn set_polling_extra_interval(&mut self, extra_interval: Duration) -> Result<()> {
+        self.polling.extra_interval = Some(extra_interval);
+        self.save()
+    }
+
+    pub(crate) fn last_polling(&self) -> Option<DateTime<Utc>> {
+        self.polling.last
+    }
+
+    pub(crate) fn set_last_polling(&mut self, last_polling: DateTime<Utc>) -> Result<()> {
+        self.polling.last = Some(last_polling);
+        self.save()
+    }
+
+    pub(crate) fn applied_package_uid(&self) -> Option<String> {
+        self.update.applied_package_uid.clone()
+    }
+
+    pub(crate) fn set_applied_package_uid(&mut self, applied_package_uid: &str) -> Result<()> {
+        self.update.applied_package_uid = Some(applied_package_uid.to_string());
+        self.save()
+    }
 }
 
 #[derive(Debug, Fail)]
-pub enum Error {
+pub(crate) enum Error {
     #[cause]
     #[fail(display = "IO error")]
     Io(io::Error),
@@ -89,18 +149,18 @@ pub enum Error {
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "PascalCase")]
-pub struct RuntimePolling {
+struct RuntimePolling {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "LastPoll")]
-    pub last: Option<DateTime<Utc>>,
+    last: Option<DateTime<Utc>>,
     #[serde(deserialize_with = "de::duration_from_int")]
     #[serde(serialize_with = "ser::duration_to_int")]
-    pub extra_interval: Option<Duration>,
-    pub retries: usize,
+    extra_interval: Option<Duration>,
+    retries: usize,
     #[serde(rename = "ProbeASAP")]
     #[serde(deserialize_with = "de::bool_from_str")]
     #[serde(serialize_with = "ser::bool_to_string")]
-    pub now: bool,
+    now: bool,
 }
 
 impl Default for RuntimePolling {
@@ -116,11 +176,11 @@ impl Default for RuntimePolling {
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "PascalCase")]
-pub struct RuntimeUpdate {
+struct RuntimeUpdate {
     #[serde(rename = "UpgradeToInstallation")]
-    pub upgrading_to: i8,
+    upgrading_to: i8,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub applied_package_uid: Option<String>,
+    applied_package_uid: Option<String>,
 }
 
 impl Default for RuntimeUpdate {
@@ -183,6 +243,7 @@ fn default() {
             applied_package_uid: None,
         },
         path: PathBuf::new(),
+        persistent: false,
     };
 
     assert_eq!(Some(settings), Some(expected));

--- a/src/states/mod.rs
+++ b/src/states/mod.rs
@@ -128,7 +128,11 @@ impl StateMachine {
 /// # }
 /// ```
 pub fn run(settings: Settings) -> Result<()> {
-    let runtime_settings = RuntimeSettings::new().load(&settings.storage.runtime_settings)?;
+    let mut runtime_settings = RuntimeSettings::new().load(&settings.storage.runtime_settings)?;
+    if !settings.storage.read_only {
+        runtime_settings.enable_persistency();
+    }
+
     let firmware = Metadata::new(&settings.firmware.metadata_path)?;
     let mut machine = StateMachine::new(settings, runtime_settings, firmware);
 


### PR DESCRIPTION
The new API allow us to control how the access is made and ensure it
saves the information when needed, without we taking into account it
is running with read-only mode or not.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>