### PR TITLE
states: Report to management server about state changes

### DIFF
--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -5,6 +5,7 @@
 use super::*;
 use firmware::tests::{create_fake_metadata, FakeDevice};
 use mockito::{mock, Mock};
+use settings::Settings;
 
 pub(crate) enum FakeServer {
     NoUpdate,
@@ -82,12 +83,10 @@ fn probe_requirements() {
     use firmware::tests::{create_fake_metadata, FakeDevice};
 
     let mock = create_mock_server(FakeServer::NoUpdate);
-    let _ = Api::new(
-        &Settings::default(),
+    let _ = Api::new(&Settings::default().network.server_address).probe(
         &RuntimeSettings::default(),
         &Metadata::new(&create_fake_metadata(FakeDevice::NoUpdate)).unwrap(),
-    )
-    .probe();
+    );
     mock.assert();
 }
 
@@ -132,8 +131,13 @@ fn download_object() {
     settings.update.download_dir = tempdir.path().to_path_buf();
 
     // Download the object.
-    let _ = Api::new(&settings, &RuntimeSettings::default(), &metadata)
-        .download_object("package_id", "object")
+    let _ = Api::new(&settings.network.server_address)
+        .download_object(
+            &metadata.product_uid,
+            "package_id",
+            &settings.update.download_dir,
+            "object",
+        )
         .expect("Failed to download the object.");
 
     // Verify it has been downloaded successfully.
@@ -147,8 +151,13 @@ fn download_object() {
     assert_eq!(downloaded, "1234".to_string());
 
     // Download the remaining bytes of the object.
-    let _ = Api::new(&settings, &RuntimeSettings::default(), &metadata)
-        .download_object("package_id", "object")
+    let _ = Api::new(&settings.network.server_address)
+        .download_object(
+            &metadata.product_uid,
+            "package_id",
+            &settings.update.download_dir,
+            "object",
+        )
         .expect("Failed to download the object.");
 
     // Verify it has been downloaded successfully.

--- a/src/firmware/metadata_value.rs
+++ b/src/firmware/metadata_value.rs
@@ -12,7 +12,7 @@ use std::{
     str::FromStr,
 };
 
-#[derive(Debug, Serialize, PartialEq, Default)]
+#[derive(Debug, Serialize, PartialEq, Default, Clone)]
 pub struct MetadataValue(BTreeMap<String, Vec<String>>);
 
 impl FromStr for MetadataValue {

--- a/src/firmware/mod.rs
+++ b/src/firmware/mod.rs
@@ -38,7 +38,7 @@ pub enum Error {
 ///
 /// The Metadata is created loading its information from the running
 /// firmware. It uses the `load` method for that.
-#[derive(Debug, Serialize, PartialEq)]
+#[derive(Debug, Serialize, PartialEq, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct Metadata {
     /// Product UID which identifies the firmware on the management system

--- a/src/states/download.rs
+++ b/src/states/download.rs
@@ -6,7 +6,9 @@ use Result;
 
 use client::Api;
 use firmware::installation_set;
-use states::{Idle, Install, State, StateChangeImpl, StateMachine, TransitionCallback};
+use states::{
+    Idle, Install, ProgressReporter, State, StateChangeImpl, StateMachine, TransitionCallback,
+};
 use std::fs;
 use update_package::{ObjectStatus, UpdatePackage};
 use walkdir::WalkDir;
@@ -22,6 +24,20 @@ create_state_step!(Download => Install(update_package));
 impl TransitionCallback for State<Download> {
     fn callback_state_name(&self) -> &'static str {
         "download"
+    }
+}
+
+impl ProgressReporter for State<Download> {
+    fn package_uid(&self) -> String {
+        self.state.update_package.package_uid()
+    }
+
+    fn report_enter_state_name(&self) -> &'static str {
+        "downloading"
+    }
+
+    fn report_leave_state_name(&self) -> &'static str {
+        "downloaded"
     }
 }
 

--- a/src/states/download.rs
+++ b/src/states/download.rs
@@ -68,8 +68,12 @@ impl StateChangeImpl for State<Download> {
                 installation_set,
                 &ObjectStatus::Incomplete,
             )) {
-            Api::new(&self.settings, &self.runtime_settings, &self.firmware)
-                .download_object(&self.state.update_package.package_uid(), object.sha256sum())?;
+            Api::new(&self.settings.network.server_address).download_object(
+                &self.firmware.product_uid,
+                &self.state.update_package.package_uid(),
+                &self.settings.update.download_dir,
+                object.sha256sum(),
+            )?;
         }
 
         if self

--- a/src/states/install.rs
+++ b/src/states/install.rs
@@ -4,7 +4,9 @@
 
 use Result;
 
-use states::{Idle, Reboot, State, StateChangeImpl, StateMachine, TransitionCallback};
+use states::{
+    Idle, ProgressReporter, Reboot, State, StateChangeImpl, StateMachine, TransitionCallback,
+};
 use update_package::UpdatePackage;
 
 #[derive(Debug, PartialEq)]
@@ -18,6 +20,20 @@ create_state_step!(Install => Reboot(update_package));
 impl TransitionCallback for State<Install> {
     fn callback_state_name(&self) -> &'static str {
         "install"
+    }
+}
+
+impl ProgressReporter for State<Install> {
+    fn package_uid(&self) -> String {
+        self.state.update_package.package_uid()
+    }
+
+    fn report_enter_state_name(&self) -> &'static str {
+        "installing"
+    }
+
+    fn report_leave_state_name(&self) -> &'static str {
+        "installed"
     }
 }
 

--- a/src/states/install.rs
+++ b/src/states/install.rs
@@ -13,7 +13,7 @@ pub(super) struct Install {
 }
 
 create_state_step!(Install => Idle);
-create_state_step!(Install => Reboot);
+create_state_step!(Install => Reboot(update_package));
 
 impl TransitionCallback for State<Install> {
     fn callback_state_name(&self) -> &'static str {

--- a/src/states/probe.rs
+++ b/src/states/probe.rs
@@ -21,7 +21,8 @@ impl StateChangeImpl for State<Probe> {
         use std::thread;
 
         let r = loop {
-            let probe = Api::new(&self.settings, &self.runtime_settings, &self.firmware).probe();
+            let probe = Api::new(&self.settings.network.server_address)
+                .probe(&self.runtime_settings, &self.firmware);
             if let Err(e) = probe {
                 error!("{}", e);
                 self.runtime_settings.inc_retries();
@@ -221,13 +222,12 @@ fn skip_same_package_uid() {
     //
     // This has been done so we don't need to manually update it every
     // time we change the package payload.
-    let probe = Api::new(
-        &Settings::default(),
-        &RuntimeSettings::default(),
-        &Metadata::new(&create_fake_metadata(FakeDevice::HasUpdate)).unwrap(),
-    )
-    .probe()
-    .unwrap();
+    let probe = Api::new(&Settings::default().network.server_address)
+        .probe(
+            &RuntimeSettings::default(),
+            &Metadata::new(&create_fake_metadata(FakeDevice::HasUpdate)).unwrap(),
+        )
+        .unwrap();
 
     if let ProbeResponse::Update(u) = probe {
         runtime_settings

--- a/src/states/reboot.rs
+++ b/src/states/reboot.rs
@@ -5,10 +5,14 @@
 use Result;
 
 use easy_process;
+
 use states::{Idle, State, StateChangeImpl, StateMachine, TransitionCallback};
+use update_package::UpdatePackage;
 
 #[derive(Debug, PartialEq)]
-pub(super) struct Reboot {}
+pub(super) struct Reboot {
+    pub(super) update_package: UpdatePackage,
+}
 
 create_state_step!(Reboot => Idle);
 
@@ -44,12 +48,15 @@ mod test {
         };
         use runtime_settings::RuntimeSettings;
         use settings::Settings;
+        use update_package::tests::get_update_package;
 
         State {
             settings: Settings::default(),
             runtime_settings: RuntimeSettings::default(),
             firmware: Metadata::new(&create_fake_metadata(FakeDevice::NoUpdate)).unwrap(),
-            state: Reboot {},
+            state: Reboot {
+                update_package: get_update_package(),
+            },
         }
     }
 

--- a/src/states/reboot.rs
+++ b/src/states/reboot.rs
@@ -6,7 +6,7 @@ use Result;
 
 use easy_process;
 
-use states::{Idle, State, StateChangeImpl, StateMachine, TransitionCallback};
+use states::{Idle, ProgressReporter, State, StateChangeImpl, StateMachine, TransitionCallback};
 use update_package::UpdatePackage;
 
 #[derive(Debug, PartialEq)]
@@ -19,6 +19,20 @@ create_state_step!(Reboot => Idle);
 impl TransitionCallback for State<Reboot> {
     fn callback_state_name(&self) -> &'static str {
         "reboot"
+    }
+}
+
+impl ProgressReporter for State<Reboot> {
+    fn package_uid(&self) -> String {
+        self.state.update_package.package_uid()
+    }
+
+    fn report_enter_state_name(&self) -> &'static str {
+        "rebooting"
+    }
+
+    fn report_leave_state_name(&self) -> &'static str {
+        "rebooted"
     }
 }
 


### PR DESCRIPTION
The state change should report to the management server before and
after the state is handled. It also should report in case of error so
it can properly track the progress of the update being processed.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>