### PR TITLE
Update actix requirement from 0.7 to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-actix-web = "0.7"
-actix = "0.7"
+actix-web = "1.0.0-alpha.6"
+actix = { version = "0.8", features = ["http"] }
 chrono = { version = "0.4", features = ["serde"] }
 crypto-hash = "0.3"
 easy_process = "0.1"

--- a/src/states/mod.rs
+++ b/src/states/mod.rs
@@ -200,10 +200,12 @@ pub fn run(settings: Settings) -> Result<(), failure::Error> {
     System::run(|| {
         let addr = agent_machine.start();
         let addr_clone = addr.clone();
-        actix_web::server::new(move || http_api::app(addr_clone.clone()))
-            .bind("localhost:8080")
-            .unwrap()
-            .start();
+        actix_web::HttpServer::new(move || {
+            actix_web::App::new().configure(|cfg| http_api::configure(cfg, addr_clone.clone()))
+        })
+        .bind("localhost:8080")
+        .unwrap()
+        .start();
 
         // Iterate over the state machine.
         loop {
@@ -211,7 +213,7 @@ pub fn run(settings: Settings) -> Result<(), failure::Error> {
                 .wait()
                 .expect("Failed to communicate with actor");
         }
-    });
+    })?;
 
     unreachable!("actix System has stopped");
 }


### PR DESCRIPTION
The actix upgrade to 0.8 requires the upgrade of actix_web to the
upcoming 1.0.0 release so we move to the development release as it is
still under development.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>