### PR TITLE
Use a generic solution for read/write timeout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ serde_ini = "0.2"
 serde_json = "1"
 structopt = "0.2"
 tempfile = "3"
+timeout-readwrite = "0.2"
 walkdir = "2"
 
 [profile.release]

--- a/src/update_package/object/copy.rs
+++ b/src/update_package/object/copy.rs
@@ -71,8 +71,8 @@ impl ObjectInstaller for Copy {
         utils::fs::mount_map(device, filesystem, mount_options, |path| {
             let dest = path.join(&self.target_path);
             let source = download_dir.join(self.sha256sum());
-            let mut input = io::BufReader::with_capacity(chunk_size, fs::File::open(source)?);
-            let mut output = io::BufWriter::with_capacity(
+            let mut input = utils::io::timed_buf_reader(chunk_size, fs::File::open(source)?);
+            let mut output = utils::io::timed_buf_writer(
                 chunk_size,
                 fs::OpenOptions::new()
                     .read(true)

--- a/src/utils/io.rs
+++ b/src/utils/io.rs
@@ -1,0 +1,30 @@
+// Copyright (C) 2019 O.S. Systems Sofware LTDA
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    io::{BufReader, BufWriter, Read, Seek, Write},
+    os::unix::io::AsRawFd,
+    time::Duration,
+};
+use timeout_readwrite::{TimeoutReader, TimeoutWriter};
+
+pub(crate) fn timed_buf_reader<R>(chunk_size: usize, reader: R) -> BufReader<TimeoutReader<R>>
+where
+    R: Read + Seek + AsRawFd,
+{
+    BufReader::with_capacity(
+        chunk_size,
+        TimeoutReader::new(reader, Duration::from_secs(5)),
+    )
+}
+
+pub(crate) fn timed_buf_writer<W>(chunk_size: usize, writer: W) -> BufWriter<TimeoutWriter<W>>
+where
+    W: Write + Seek + AsRawFd,
+{
+    BufWriter::with_capacity(
+        chunk_size,
+        TimeoutWriter::new(writer, Duration::from_secs(5)),
+    )
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,3 +3,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub(crate) mod fs;
+pub(crate) mod io;


### PR DESCRIPTION
The timeout-readwrite crate is used to enable the supervision on the
Read and Write supported objects. It does it using the poll syscall
internally.

Now, our code has a generic 5 seconds timeout for read/write.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>