### PR TITLE
updatehub: Add Vagrant for testing with root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 Cargo.lock
 .\#*
 \#*
+.vagrant

--- a/README.md
+++ b/README.md
@@ -9,3 +9,16 @@ should not be used in production yet.
 
 For the official UpdateHub agent, please use the
 https://github.com/UpdateHub/UpdateHub repository instead.
+
+## Running tests
+
+Some tests are marked as ignored because they requoire user previleges. There's a Vagrantfile that can be used to run them. To run tests on the virtual machine run:
+
+```Bash
+vagrant up
+vagrant ssh
+sudo -i
+cd /vagrant
+cargo test
+cargo test -- --ignored
+```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,11 @@
+Vagrant.configure("2") do |config|
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 2048
+  end
+  config.vm.box = "debian/buster64"
+  config.vm.provision "shell",
+    inline: <<-EOS
+      apt-get install -y curl git gcc libssl-dev pkg-config mtd-utils
+      curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+EOS
+end

--- a/updatehub/src/object/installer/flash.rs
+++ b/updatehub/src/object/installer/flash.rs
@@ -96,31 +96,6 @@ mod tests {
 
     #[test]
     #[ignore]
-    fn install_nand() {
-        let _mtd_lock = SERIALIZE.lock();
-        let mtd = FakeMtd::new(&["system0"], MtdKind::Nand).unwrap();
-        let target = &mtd.devices[0];
-        let flash_obj = fake_flash_obj("system0");
-        let download_dir = tempfile::tempdir().unwrap();
-        let source = download_dir.path().join(&flash_obj.sha256sum);
-
-        let (_handle, calls) = create_echo_bins(&["flash_erase", "flashcp", "nandwrite"]).unwrap();
-
-        flash_obj.check_requirements().unwrap();
-        flash_obj.install(download_dir.path()).unwrap();
-
-        let expected = format!(
-            "flash_erase {} 0 0\nnandwrite -p {} {}\n",
-            target.to_str().unwrap(),
-            target.to_str().unwrap(),
-            source.to_str().unwrap()
-        );
-
-        assert_eq!(std::fs::read_to_string(calls).unwrap(), expected);
-    }
-
-    #[test]
-    #[ignore]
     fn install_nor() {
         let _mtd_lock = SERIALIZE.lock();
         let mtd = FakeMtd::new(&["system0"], MtdKind::Nor).unwrap();


### PR DESCRIPTION
Add Vagrantfile for running ignored tests that require superuser previleges,
cutdown some tests aspects for nand devices.

Signed-off-by: Jonathas-Conceicao <jonathas.conceicao@ossystems.com.br>